### PR TITLE
Fix various Linux build issues

### DIFF
--- a/Build/MakeGMakeProjects.sh
+++ b/Build/MakeGMakeProjects.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+premake5 gmake2

--- a/Build/module.lua
+++ b/Build/module.lua
@@ -119,6 +119,12 @@ function CreateProtobufProject(basePath)
         {
             "HAVE_PTHREAD"
         }
+
+        filter { "action:gmake*", "language:C++" }
+            buildoptions { "-fPIC" }
+            linkoptions ("-fPIC")
+
+        filter ""
 end
 
 function CreateSteamNetProject(basePath)
@@ -201,10 +207,6 @@ function CreateSteamNetProject(basePath)
         links
         {
             "protobuf",
-            "libcryptoMT.lib",
-            "libsslMT.lib",
-            "ws2_32",
-            "Crypt32.lib"
         }
         
         filter { "architecture:*86" }
@@ -212,6 +214,24 @@ function CreateSteamNetProject(basePath)
 
         filter { "architecture:*64" }
             libdirs { basePath .. "/ThirdParty/openssl/lib/x64" }
+
+        filter { "action:vs*" }
+            links
+            {
+                "libcryptoMT.lib",
+                "libsslMT.lib",
+                "ws2_32",
+                "Crypt32.lib"
+            }
         
+        filter { "action:gmake*", "language:C++" }
+            defines
+            {
+                'POSIX',
+                'LINUX',
+                'GNUC',
+                'GNU_COMPILER',
+            }
+
         filter ""
 end

--- a/Build/premake5.lua
+++ b/Build/premake5.lua
@@ -34,7 +34,7 @@ workspace ("Tilted Connect")
         buildoptions { "/wd4512", "/wd4996", "/wd4018", "/Zm500" }
         defines { "WIN32" }
         
-    filter { "action:gmake2", "language:C++" }
+    filter { "action:gmake*", "language:C++" }
         buildoptions { "-g -fpermissive" }
         linkoptions ("-lm -lpthread -pthread -Wl,--no-as-needed -lrt -g -fPIC")
             
@@ -49,11 +49,11 @@ workspace ("Tilted Connect")
         symbols ( "On" )
         
     filter { "architecture:*86" }
-        libdirs { "lib/x32" }
+        libdirs { "lib/x32", "../../TiltedCore/Build/lib/x32" }
         targetdir ("lib/x32")
 
     filter { "architecture:*64" }
-        libdirs { "lib/x64" }
+        libdirs { "lib/x64", "../../TiltedCore/Build/lib/x64" }
         targetdir ("lib/x64")
         
     filter {}

--- a/Code/tests/src/main.cpp
+++ b/Code/tests/src/main.cpp
@@ -1,14 +1,24 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
+#ifdef _WIN32
 #include <windows.h>
+#else
+#endif
 #include <Platform.h>
 
+#ifdef _WIN32
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
 {
     TP_UNUSED(hInstance);
     TP_UNUSED(hPrevInstance);
     TP_UNUSED(lpCmdLine);
     TP_UNUSED(nShowCmd);
+#else
+int main(int aArgc, char** apArgv)
+{
+    TP_UNUSED(aArgc);
+    TP_UNUSED(apArgv);
 
+#endif
     return Catch::Session().run();
 }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+PROJECTS := Connect Tests protobuf SteamNet
+FORWARDED := clean help ${PROJECTS}
+
+ifeq ($(shell uname -m),x86_64)
+	platform := x64
+else
+	platform := x32
+endif
+
+config := debug
+premake_config = ${config}_${platform}
+
+.PHONY: all tests $(FORWARDED)
+
+all: Build/projects
+	$(MAKE) -C Build/projects all config=${premake_config}
+
+tests: all
+	Build/lib/${platform}/Tests
+
+Build/projects:
+	cd Build && ./MakeGMakeProjects.sh
+
+$(PROJECTS): Build/projects
+	$(MAKE) -C Build/projects $@ config=${premake_config}
+


### PR DESCRIPTION
Issues fixed;
- Protobuf needs to be built with `-fPIC` to be linkable against a shared lib
- SteamNet doesn't require additional link libs on Linux
  - it does require platform defines on the other hand
- The libdir needs to be set correctly to find the Core lib from TiltedCore
- And finally, the test binary can't use any Windows-exclusive semantics.