### PR TITLE
feat: listen on IPv6 by default

### DIFF
--- a/Code/connect/include/Client.hpp
+++ b/Code/connect/include/Client.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include "steam/steamnetworkingsockets.h"
 #include "SteamInterface.hpp"
 #include "SynchronizedClock.hpp"

--- a/Code/connect/include/Server.hpp
+++ b/Code/connect/include/Server.hpp
@@ -16,7 +16,7 @@ namespace TiltedPhoques
 
         TP_NOCOPYMOVE(Server);
 
-        bool Host(uint16_t aPort, uint32_t aTickRate) noexcept;
+        bool Host(uint16_t aPort, uint32_t aTickRate, bool bEnableDualStackIP = true) noexcept;
         void Close() noexcept;
 
         void Update() noexcept;

--- a/Code/connect/src/Server.cpp
+++ b/Code/connect/src/Server.cpp
@@ -34,13 +34,20 @@ namespace TiltedPhoques
         SteamInterface::Release();
     }
 
-    bool Server::Host(const uint16_t aPort, uint32_t aTickRate) noexcept
+    bool Server::Host(const uint16_t aPort, uint32_t aTickRate, bool bEnableDualStackIP) noexcept
     {
         Close();
 
         SteamNetworkingIPAddr localAddress{};  // NOLINT(cppcoreguidelines-pro-type-member-init)
-        localAddress.Clear();
-        localAddress.m_port = aPort;
+        if (bEnableDualStackIP)
+        {
+            localAddress.Clear();
+            localAddress.m_port = aPort;
+        }
+        else
+        {
+            localAddress.SetIPv4(0, aPort);
+        }
 
         SteamNetworkingConfigValue_t opt = {};
         opt.SetPtr(k_ESteamNetworkingConfig_Callback_ConnectionStatusChanged, reinterpret_cast<void*>(&SteamNetConnectionStatusChangedCallback));


### PR DESCRIPTION
By default, the server will listen on both IPv4 and IPv6 which causes issues for some users. This PR makes it so that the server defaults to running on IPv4 and can optionally run on IPv6 as well.

Partially fixes https://github.com/tiltedphoques/TiltedEvolution/issues/473
I will do another PR for adding the server config option to control the behavior.