### PR TITLE
Fix xmake.lua for Abseil update

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -9,7 +9,8 @@ add_requires("tiltedcore v0.2.7", "hopscotch-map v2.3.1", "snappy 1.1.10", "game
 add_requireconfs("*.mimalloc", { version = "2.1.7", override = true })
 add_requireconfs("*.openssl", { version = "1.1.1-w", override = true })
 add_requireconfs("*.cmake", { version = "3.30.2", override = true })
-add_requireconfs("*.protobuf*", { version = "26.1", override = true, build = true }) -- needs build or else linker screams
+add_requireconfs("*.protobuf*", { version = "26.1", override = true }) 
+add_requireconfs("**.abseil*", { version = "20250127.1", override = true }) 
 
 add_rules("mode.debug","mode.releasedbg", "mode.release")
 add_rules("plugin.vsxmake.autoupdate")


### PR DESCRIPTION
Abseil update 20250512 is not compatible with the released version of GameNetworkingSockets or protobuf version 26.1 that we use. Protobuf has been updated but the release version of GameNetworkingSockets has not yet been updated.

Abseil wasn't pinned, it is now pinned at 20250127.1 for everything that pulls it in. This was the minimal change I could find, and safer than trying to move to the master branch of GameNetworkingSockets.

I don't have access to the CI environment so I can test there. But this version has been tested against a stock 1.7.1 server and syncing a character with this version with a character running a version from before the Abseil change. All seemed fine.