### PR TITLE
Remove version pin for tiltedcore dependency

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -3,7 +3,7 @@ set_languages("cxx20")
 set_xmakever("2.5.1")
 
 -- direct dependency version pinning
-add_requires("tiltedcore v0.2.7", "hopscotch-map v2.3.1", "snappy 1.1.10", "gamenetworkingsockets v1.4.1", "catch2 2.13.9", "libuv v1.48.0")
+add_requires("tiltedcore", "hopscotch-map v2.3.1", "snappy 1.1.10", "gamenetworkingsockets v1.4.1", "catch2 2.13.9", "libuv v1.48.0")
 
 -- dependencies' dependencies version pinning
 add_requireconfs("*.mimalloc", { version = "2.1.7", override = true })


### PR DESCRIPTION
Submodules inherit pins from their parent, so it is counter-productive to have pins in them.